### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Complete CI/CD pipeline infrastructure with GitHub Actions
-- Comprehensive test suite with scientific validation
-- Performance benchmarking and regression detection
-- Security scanning and dependency analysis
+## [0.5.0] - 2026-04-18
 
-### Changed
-- Enhanced package metadata for better PyPI discovery
-- Improved documentation structure and content
-- Updated development dependencies and tooling
+### Fixed
+- `datepathlist()` now respects the `lfrequency` parameter. Previously it
+  hardcoded a daily interval regardless of requested frequency, so hourly
+  (e.g. `"1H"`, `"3H"`) GNSS receiver downloads fell back to daily intervals.
+  Added private helper `_parse_frequency_to_timedelta()` supporting H/D/W/M/S
+  units. Backward compatible: empty/None defaults to daily, 8H session logic
+  unchanged.
+
+### Added
+- **Package-level RINEX API**: `rinex2_filename`, `rinex3_filename`,
+  `rinex_filename`, `parse_rinex2_filename`, `parse_rinex3_filename`, and
+  `convert_rinex_filename` are now importable directly from `gtimes`.
+- **`rinex3_filename(uppercase=...)`** optional flag for uppercase station
+  IDs (default lowercase per RINEX 3 standard).
+- **Time-range helpers in `timefunc`** for domain-generic time-series
+  iteration: `previous_complete_period`, `generate_time_range`,
+  `generate_datetime_list`, `generate_period_ranges`. All accept frequency
+  as timedelta or string; end-exclusive to avoid reading mid-write periods.
+- **`parse_datetime_flexible()`** multi-format datetime parser (ISO 8601,
+  caller-supplied formats, built-in fallbacks).
+- **`timecalc` CLI flags**: `--rin2`, `--rin3`, `--rinex-convert`,
+  `--rinex-parse` for RINEX filename generation, conversion, and parsing.
+
+### Tests
+- 40+ new tests covering hourly frequency handling, RINEX round-trip
+  generation/parsing, time-range iteration, and flexible datetime parsing.
 
 ## [0.4.0] - 2024-12-02
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gtimes"
-version = "0.4.1"
+version = "0.5.0"
 description = "High-precision GPS time conversion and processing library for GNSS applications"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/gtimes/__init__.py
+++ b/src/gtimes/__init__.py
@@ -1,6 +1,6 @@
 """GTimes - High-precision GPS time conversion and processing library."""
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __author__ = "Benedikt Gunnar Ófeigsson"
 __email__ = "bgo@vedur.is"
 

--- a/src/gtimes/timecalc.py
+++ b/src/gtimes/timecalc.py
@@ -26,7 +26,7 @@ def _get_version() -> str:
             from gtimes import __version__
             return __version__
         except ImportError:
-            return "0.4.1"  # Development fallback
+            return "0.5.0"  # Development fallback
 
 
 def datestr(string: str) -> datetime.datetime:


### PR DESCRIPTION
## Summary

Version bump to 0.5.0 following the merge of #3.

- `pyproject.toml`, `src/gtimes/__init__.py`, `src/gtimes/timecalc.py`: 0.4.1 → 0.5.0
- `CHANGELOG.md`: add [0.5.0] entry summarizing PR #3 content

Minor (not patch) because #3 added new public API surface:
- Package-level RINEX exports (`rinex2_filename`, `rinex3_filename`, `rinex_filename`, `parse_rinex2_filename`, `parse_rinex3_filename`, `convert_rinex_filename`)
- Four new `timefunc` helpers (`previous_complete_period`, `generate_time_range`, `generate_datetime_list`, `generate_period_ranges`)
- `parse_datetime_flexible`
- Four new `timecalc` CLI flags (`--rin2`, `--rin3`, `--rinex-convert`, `--rinex-parse`)
- `rinex3_filename(uppercase=...)` option

## Test plan

- [ ] CI passes
- [ ] `gtimes.__version__` reports `"0.5.0"` after install
- [ ] `timecalc --version` reports `0.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)