### PR TITLE
fix: parse_rinex2_filename now recognises .YYd Hatanaka extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `parse_rinex2_filename` now recognises `.YYd` Hatanaka-compressed observation
+  files (e.g. `ELDC0150.26d`). Previously the regex only matched `[ongmlh]`, so
+  Hatanaka filenames silently returned `None`.
+
 ## [0.5.0] - 2026-04-18
 
 ### Fixed

--- a/src/gtimes/timefunc.py
+++ b/src/gtimes/timefunc.py
@@ -1419,7 +1419,9 @@ def parse_rinex2_filename(filename: str) -> Optional[Dict[str, Any]]:
     basename = os.path.basename(filename)
 
     # Pattern: SSSS0DDS.YYt
-    pattern = r'^([A-Za-z0-9]{4})(\d{3})([0-9a-z])\.(\d{2})([ongmlh])$'
+    # File type characters: o=observation, d=Hatanaka-compressed observation,
+    # n=GPS nav, g=GLONASS nav, m=met, l=Galileo nav, h=SBAS nav
+    pattern = r'^([A-Za-z0-9]{4})(\d{3})([0-9a-z])\.(\d{2})([ongmlhd])$'
     match = re.match(pattern, basename, re.IGNORECASE)
 
     if not match:

--- a/tests/test_timefunc.py
+++ b/tests/test_timefunc.py
@@ -390,6 +390,16 @@ class TestParseRinex2Filename:
         assert parsed is not None
         assert parsed["year"] == 1999
 
+    def test_parse_hatanaka_file(self):
+        """Test parsing Hatanaka-compressed observation file (.YYd)."""
+        parsed = parse_rinex2_filename("ELDC0150.26d")
+        assert parsed is not None
+        assert parsed["station"] == "ELDC"
+        assert parsed["doy"] == 15
+        assert parsed["year"] == 2026
+        assert parsed["file_type"] == "d"
+        assert parsed["session"] == "0"
+
     def test_invalid_filename(self):
         """Test parsing invalid filename returns None."""
         parsed = parse_rinex2_filename("invalid.txt")


### PR DESCRIPTION
## Summary

- RINEX 2 short-name files use `.YYd` to indicate Hatanaka-compressed observation data (equivalent data to `.YYo`, just compressed differently)
- The regex in `parse_rinex2_filename` only matched `[ongmlh]`, so filenames like `ELDC0150.26d` silently returned `None`
- Any code that tries to track or look up Hatanaka files by parsing the filename would silently skip them

## Change

Added `d` to the file-type character class in the regex and added a test case:

```python
# Before
pattern = r'^([A-Za-z0-9]{4})(\d{3})([0-9a-z])\.(\d{2})([ongmlh])$'

# After
pattern = r'^([A-Za-z0-9]{4})(\d{3})([0-9a-z])\.(\d{2})([ongmlhd])$'
```

## Test plan

- [ ] `pytest tests/test_timefunc.py::TestParseRinex2Filename` — all 5 tests pass including new `test_parse_hatanaka_file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)